### PR TITLE
Fixes #6: Execute with no CL argument, prompt user for another file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ To begin using _Lust_, please follow the steps outlined below:
 1. Clone _Lust_ to your local workstation using Terminal or Git Bash: `git clone https://github.com/SeanPrashad/Lust.git`
 2. Navigate into the root level of the folder; ex: `cd ~/repos/Lust`
 3. Build the `Cargo` project using: `cargo build`
-4. Run the project whilst supplying a **single command-line argument** of the **absolute path** for a file you'd like to diagnose; ex: `cargo run lazydog.txt` (where `lazydog.txt` is in the root level folder of our `Cargo` project)
+4. Run the project whilst supplying a **single command-line argument** (optional) of the **absolute path** for a file you'd like to diagnose; ex: `cargo run lazydog.txt` (where `lazydog.txt` is in the root level folder of our `Cargo` project)
 5. Marvel in awe at the results!
-6. **Bonus**: Repeat for another file
+6. You'll be prompted for another file or enter `q` OR `Q` to exit
+
 
 ## Functionality:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,63 +1,122 @@
-extern crate sha1;  // For use of SHA1 functions
-extern crate md5;   // For use of MD5 functions
+extern crate sha1; // For use of SHA1 functions
+extern crate md5; // For use of MD5 functions
 
 use std::env;
 use std::fs;
 use std::fs::File;
 use std::path::Path;
-use std::io::prelude::*;
+use std::io::prelude:: * ;
+use std::io;
 
 /*
-    To run program: cargo run [File_Name_Goes_Here_As_Command_Line_Argument]
-        ex: cargo run lazydog.txt
+    To run program: 
+        `cargo run` [File_Name_Goes_Here_As_Command_Line_Argument]
+         ex: cargo run lazydog.txt
+         
+        `cargo run` Prompt user for file name
+
+        q OR Q to exit the program    
 */
 
-fn main(){
-    let args: Vec<String> = env::args().collect();
+fn main() {
+  let args: Vec < String > = env::args().collect();
 
-    // File I/O: https://doc.rust-lang.org/book/second-edition/ch12-02-reading-a-file.html
-    get_file_name(&args[1]);
-    get_file_size(&args[1]);
-    generate_sha(&args[1]);
-    generate_md5(&args[1]);
+  // File I/O: https://doc.rust-lang.org/book/second-edition/ch12-02-reading-a-file.html
+  //checks if user passed in a file name through the command line
+  if args.len() > 1 {
+    file_processor( & args[1]);
+  }
+
+  let mut quit: bool = false;
+
+  // Continue loop until user exits program
+  while !quit {
+
+    io::stdout().flush().unwrap();
+
+    print!("\nEnter a valid file path | quit(q|Q): ");
+    io::stdout().flush().unwrap();
+    let mut input = String::new();
+
+    io::stdin().read_line( & mut input).ok().expect(
+      "Couldn't read line",
+    );
+
+    //validate_file(&String) returns the current state
+    quit = validate_file( & input);
+  }
 }
 
-fn get_file_name(file_path: &String) -> () {
-    let path = Path::new(file_path);
-    println!("File name: {:?}", path.file_name().unwrap());
+fn validate_file(file_path: & String) -> bool {
+
+//checks if file name entered by the user is valid
+  let is_valid = Path::new(file_path.trim()).exists();
+
+  //exits program if user enters (q|Q)
+  if file_path.trim().to_uppercase() == "Q" {
+    return true;
+  }
+
+  if !is_valid {
+    println!("Error: '{}' was not found", file_path.trim());
+  } else {
+    //if the file is valid, begin to process the data
+    file_processor(file_path);
+  }
+  return false;
+}
+
+fn file_processor(file_path: & String) {
+
+  get_file_name(file_path);
+  get_file_size(file_path);
+  generate_sha(file_path);
+  generate_md5(file_path);
+}
+
+fn get_file_name(file_path: & String) {
+  let path = Path::new(file_path.trim());
+  println!("\nFile name: {:?}", path.file_name().unwrap());
 }
 
 /*
     [21:42:20]  <wyvern>    Depending on the sort of code you’re writing, you could display a nice error message, or get user input for a better file path to look at, or just crash if you’re writing a test or a throwaway experiment
 */
 
-fn get_file_size(file_path: &String) -> () {
-    match fs::metadata(file_path)
-    { 
-        Ok(metadata) => { println!("File size: {:?} bytes", metadata.len()); },
-        Err(e) => { println!("Error fetching file metadata! {:?}", e); } 
+fn get_file_size(file_path: & String) -> () {
+  match fs::metadata(file_path.trim()) {
+    Ok(metadata) => {
+      println!("File size: {:?} bytes", metadata.len());
     }
+    Err(e) => {
+      println!("Error fetching file metadata! {:?}", e);
+    }
+  }
 }
 
-fn generate_sha(file_path: &String) -> () {
-    let mut file = File::open(file_path).expect("File Not Found!");
+fn generate_sha(file_path: & String) -> () {
+  let mut file = File::open(file_path.trim()).expect("File Not Found!");
 
-    let mut file_contents = String::new();
-    file.read_to_string(&mut file_contents).expect("Something went wrong reading the file!");
+  let mut file_contents = String::new();
+  file.read_to_string( & mut file_contents).expect(
+    "Something went wrong reading the file!",
+  );
 
-    let mut sha_hash = sha1::Sha1::new();
-    sha_hash.update(file_contents.as_bytes());
+  let mut sha_hash = sha1::Sha1::new();
+  sha_hash.update(file_contents.as_bytes());
 
-    println!("SHA1 hash: {:?}", sha_hash.digest().to_string());
+  println!("SHA1 hash: {:?}", sha_hash.digest().to_string());
 }
 
-fn generate_md5(file_path: &String) -> () {
-    let mut file = File::open(file_path).expect("File Not Found!");
+fn generate_md5(file_path: & String) -> () {
+  let mut file = File::open(file_path.trim()).expect("File Not Found!");
 
-    let mut file_contents = String::new();
-    file.read_to_string(&mut file_contents).expect("Something went wrong reading the file!");
+  let mut file_contents = String::new();
+  file.read_to_string( & mut file_contents).expect(
+    "Something went wrong reading the file!",
+  );
 
-    let md5 = md5::compute(file_contents);
+  let md5 = md5::compute(file_contents);
 
-    println!("MD5 hash: \"{:x}\"", md5);
+  println!("MD5 hash: \"{:x}\"", md5);
 }


### PR DESCRIPTION
**New features:**
*Run the application without a command line argument
*User is reprompted for another file until the user quits the program
*Enter q OR Q to quit the application 
*Visual output changes for prompts and errors
